### PR TITLE
Fix: attach searchBar with logo in main page

### DIFF
--- a/src/components/home/navigation.tsx
+++ b/src/components/home/navigation.tsx
@@ -121,7 +121,7 @@ export function Navigation({ isLogin }: NavigationProps) {
 
       <NavLogo />
       {/* Search Bar - flexible, adjusts size based on available space */}
-      <div className="grow w-full">
+      <div className="grow w-full ml-4">
         <SearchBar />
       </div>
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#27
> ex) #이슈번호, #이슈번호

## 📝작업 내용
main 페이지에서 Logo와 searchBar가 Mobile View가 되기 전에 붙는 현상이 발생해서 이에 관련해서 수정했습니다.
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
## Before
<img width="699" alt="스크린샷 2024-11-02 오후 5 17 42" src="https://github.com/user-attachments/assets/b8674730-7f2c-47e5-a938-d0351a85b073">
## After
<img width="756" alt="스크린샷 2024-11-02 오후 5 16 07" src="https://github.com/user-attachments/assets/266bb1c6-344c-4c6f-aaa1-c5849f16c5f9">

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

